### PR TITLE
Display custom linked products tab on "Create New Product" page

### DIFF
--- a/app/code/community/Inchoo/CustomLinkedProducts/Block/Adminhtml/Catalog/Product/Edit/Tab.php
+++ b/app/code/community/Inchoo/CustomLinkedProducts/Block/Adminhtml/Catalog/Product/Edit/Tab.php
@@ -37,7 +37,9 @@ implements Mage_Adminhtml_Block_Widget_Tab_Interface
 {
     public function canShowTab() 
     {
-        return true;
+        return (($this->getRequest()->getActionName() === 'new') && (!$this->getRequest()->getParam('set')))
+            ? false
+            : true;
     }
 
     public function getTabLabel() 

--- a/app/code/community/Inchoo/CustomLinkedProducts/controllers/Adminhtml/Catalog/ProductController.php
+++ b/app/code/community/Inchoo/CustomLinkedProducts/controllers/Adminhtml/Catalog/ProductController.php
@@ -55,7 +55,7 @@ class Inchoo_CustomLinkedProducts_Adminhtml_Catalog_ProductController extends Ma
         $this->_initProduct();
         $this->loadLayout();
         $this->getLayout()->getBlock('catalog.product.edit.tab.custom')
-            ->setProductsRelated($this->getRequest()->getPost('products_custom', null));
+            ->setProductsCustom($this->getRequest()->getPost('products_custom', null));
         $this->renderLayout();
     }
 

--- a/app/design/adminhtml/default/default/layout/inchoo_customlinkedproducts.xml
+++ b/app/design/adminhtml/default/default/layout/inchoo_customlinkedproducts.xml
@@ -34,15 +34,22 @@
 -->
 
 <layout>
-    
-    <adminhtml_catalog_product_edit>
+    <inchoo_customlinkedproducts_inject_tab>
         <reference name="product_tabs">
             <action method="addTab">
                 <name>custom</name>
                 <block>inchoo_customlinkedproducts/adminhtml_catalog_product_edit_tab</block>
             </action>
         </reference>
+    </inchoo_customlinkedproducts_inject_tab>
+
+    <adminhtml_catalog_product_edit>
+        <update handle="inchoo_customlinkedproducts_inject_tab"/>
     </adminhtml_catalog_product_edit>
+
+    <adminhtml_catalog_product_new>
+        <update handle="inchoo_customlinkedproducts_inject_tab" />
+    </adminhtml_catalog_product_new>
     
     <adminhtml_catalog_product_custom>
         <block type="core/text_list" name="root" output="toHtml">


### PR DESCRIPTION
- Display custom linked tab on "New product" page via Layout XML
- Calling setProductsCustom( ) instead of setProductsRelated( ) in customGrid action (Inchoo_CustomLinkedProducts_Adminhtml_Catalog_ProductController)